### PR TITLE
Fix property path for definitions

### DIFF
--- a/lib/commands/openapi.js
+++ b/lib/commands/openapi.js
@@ -95,12 +95,8 @@ module.exports = {
 
       if (
         definition.hasOwnProperty('properties')
-        &&
-        definition.properties.hasOwnProperty('attributes')
-        &&
-        definition.properties.attributes.hasOwnProperty('properties')
       ) {
-        let attributes = definition.properties.attributes.properties;
+        let attributes = definition.properties;
 
         let attr = {};
         _.each(attributes, function(attribute, attrName) {

--- a/lib/commands/openapi.js
+++ b/lib/commands/openapi.js
@@ -98,6 +98,16 @@ module.exports = {
       ) {
         let attributes = definition.properties;
 
+        // jsonapi-server seems to nest the properties more deeply than usual.
+        // If the definition contains `properties.attributes.properties`, use that instead of just `properties`.
+        if (
+          definition.properties.hasOwnProperty('attributes')
+          &&
+          definition.properties.attributes.hasOwnProperty('properties')
+        ) {
+          attributes = definition.properties.attributes.properties;
+        }
+
         let attr = {};
         _.each(attributes, function(attribute, attrName) {
           // @TODO Required.


### PR DESCRIPTION
No models were being generated, as the parser was expecting properties to be nested under a deeper path than they are (`properties.attributes.properties` vs `properties`).

This change fixes it for the [pet store example](http://petstore.swagger.io/v2/swagger.json) from swagger.io, as well as other cases I've tried.  If there's a valid reason to support the `properties.attributes.properties` path, I'm happy to update this PR with a check so that the deeper path is used it present (falling back to simply `properties`) - juts let me know.