### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Generate Ember models from an OpenAPI schema.
 
+## Installation
+
+```
+ember install ember-cli-openapi-generate
+```
+
 ## Usage
 
 ```
@@ -23,29 +29,3 @@ You can easily spin up a JSONAPI compliant Node/Express server backed by Mongo (
 * https://swagger.io
 * https://github.com/OAI/OpenAPI-Specification
 * https://github.com/holidayextras/jsonapi-server/blob/master/documentation/swagger.md
-
-This README outlines the details of collaborating on this Ember addon.
-
-## Installation
-
-* `git clone <repository-url>` this repository
-* `cd ember-cli-openapi-generate`
-* `npm install`
-* `bower install`
-
-## Running
-
-* `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
-
-## Running Tests
-
-* `npm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
-
-## Building
-
-* `ember build`
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).


### PR DESCRIPTION
Remove the irrelevant sections generated by ember-cli and replace them with relevant installation instructions.