### PR TITLE
Support local swagger files as well as HTTP(S)-accessible ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ ember install ember-cli-openapi-generate
 ## Usage
 
 ```
+# Generate from a web-accessible swagger.json
 $ ember openapi https://example.com/api/swagger.json
+
+# Or, generate from a local file
+$ ember openapi /path/to/your/swagger.json
 ```
 ### Options
 

--- a/lib/commands/openapi.js
+++ b/lib/commands/openapi.js
@@ -4,6 +4,7 @@ let q = require('q');
 let request = require('request');
 let _ = require('lodash');
 let Blueprint = require('ember-cli/lib/models/blueprint');
+let fs = require('fs');
 // let Inflector = require('ember-inflector');
 
 module.exports = {
@@ -34,7 +35,7 @@ module.exports = {
     self.options = _.defaults(commandOptions, self.options);
 
     if ( ! rawArgs.length ) {
-      self.ui.writeLine('Please specify the URI to the OpenAPI schema as the first argument. eg: ember openapi https://example.com/api/swagger.json');
+      self.ui.writeLine('Please specify the URI or path to the OpenAPI schema as the first argument. eg: ember openapi https://example.com/api/swagger.json');
       return;
     }
     else {
@@ -172,14 +173,27 @@ module.exports = {
     let self = this;
     let deferred = q.defer();
 
-    request(uri, function (error, response, body) {
-      if ( error ) {
-        deferred.reject(error);
-      }
-      else {
-        deferred.resolve(JSON.parse(body));
-      }
-    });
+    if (uri.search(/^https?:/) !== -1) {
+      // Looks like a URL; try fetching
+      request(uri, function (error, response, body) {
+        if ( error ) {
+          deferred.reject(error);
+        }
+        else {
+          deferred.resolve(JSON.parse(body));
+        }
+      });
+    } else {
+      // Doesn't look like a URL; it's probably a local file path
+      fs.readFile(uri, 'utf8', function(error, body) {
+        if ( error ) {
+          deferred.reject(error);
+        }
+        else {
+          deferred.resolve(JSON.parse(body));
+        }
+      })
+    }
 
     return deferred.promise;
   },


### PR DESCRIPTION
This change allows a local file path to be specified instead of a web-accessible URL, allowing local files to be used without needing to first upload them to somewhere which Node can fetch from.  URLs can still be used, so this simply adds a bit of flexibility.