### PR TITLE
Add yaml file support

### DIFF
--- a/lib/commands/openapi.js
+++ b/lib/commands/openapi.js
@@ -5,6 +5,7 @@ let request = require('request');
 let _ = require('lodash');
 let Blueprint = require('ember-cli/lib/models/blueprint');
 let fs = require('fs');
+let yaml = require('js-yaml');
 // let Inflector = require('ember-inflector');
 
 module.exports = {
@@ -16,6 +17,7 @@ module.exports = {
     cli: false,
     resource: false,
     arraytype: false,
+    yaml: false,
   },
 
   anonymousOptions: [
@@ -26,6 +28,7 @@ module.exports = {
     { name: 'cli', type: Boolean, description: 'Generate cli commands instead of model files.' },
     { name: 'resource', type: Boolean, description: 'Generate resources instead of models (models, routes, templates and tests).' },
     { name: 'arraytype', type: Boolean, description: 'Arrays are an allowed type: you need to have an "array" transform.' },
+    { name: 'yaml', type: Boolean, description: 'Treat OpenAPI file as YAML.' },
   ],
 
   /**
@@ -223,6 +226,7 @@ module.exports = {
   _fetch: function(uri) {
     let self = this;
     let deferred = q.defer();
+    let parseText = self.options.yaml ? yaml.load : JSON.parse;
 
     if (uri.search(/^https?:/) !== -1) {
       // Looks like a URL; try fetching
@@ -231,7 +235,7 @@ module.exports = {
           deferred.reject(error);
         }
         else {
-          deferred.resolve(JSON.parse(body));
+          deferred.resolve(parseText(body));
         }
       });
     } else {
@@ -241,7 +245,7 @@ module.exports = {
           deferred.reject(error);
         }
         else {
-          deferred.resolve(JSON.parse(body));
+          deferred.resolve(parseText(body));
         }
       })
     }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.12.0",
     "ember-cli-htmlbars": "^2.0.3",
+    "js-yaml": "^3.11.0",
     "lodash": "^4.17.4",
     "q": "^1.5.0",
     "request": "^2.81.0"


### PR DESCRIPTION
Swagger has depcrecated support of JSON definition files in favor of YAML. The new syntax is much more readable, but unfortunately is not supported by this tool. Rather than force people to convert between formats, it would be better for the tool to support both.

This comit adds a --yaml flag to designate that the OpenAPI document is yaml. If not provided, the default of json is assumed.